### PR TITLE
Update .platform.app.yaml

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -9,6 +9,10 @@ type: php:7.4
 build:
     flavor: composer
 
+dependencies:
+    php:
+        composer/composer: '^2.0'
+
 variables:
     env:
         # Tell Symfony to always install in production-mode.


### PR DESCRIPTION
Some project require composer 2.0
If you are using Symfony 5 with doctrine/migrations then this depends on ocramius/proxy-manager which has composer 2.0 as a hard requirement.
Besides Doctrine migrations being a common package, I think using composer 2 is good as default for Symfony 5.